### PR TITLE
Set the 'build-backend' key in the build-system section

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,3 +23,4 @@ Repository = "https://github.com/microsoft/py-deviceid"
 
 [build-system]
 requires = ["setuptools"]
+build-backend = "setuptools.build_meta"


### PR DESCRIPTION
According to PEP 517[0], if the build-backend isn't specified, `setuptools.build_meta.__legacy__` is an acceptable alternative, which requires a `setup.py` file.

As this repository doesn't have a `setup.py`, this leads to build failures if tools opt to use that default. Explicitly specify the modern setuptools backend so the package can be built by tooling that uses the legacy alternative by default.

[0] https://peps.python.org/pep-0517/