### PR TITLE
Added secure release pipeline

### DIFF
--- a/azure-pipelines/azure-pipeline.yml
+++ b/azure-pipelines/azure-pipeline.yml
@@ -21,13 +21,13 @@ resources:
   - repository: MicrobuildTemplate
     type: git
     name: 1ESPipelineTemplates/MicroBuildTemplate
-    ref: refs/heads/release
+    ref: refs/tags/release
 
 extends:
   # The pipeline extends the 1ES PT which will inject different SDL and compliance tasks.
   # For non-production pipelines, use "Unofficial" as defined below.
   # For productions pipelines, use "Official".
-  template: /azure-pipelines/MicroBuild.1ES.Official.Publish.yml@MicroBuildTemplate
+  template: azure-pipelines/MicroBuild.1ES.Official.yml@MicroBuildTemplate
   parameters:
     customBuildTags:
     - Ignore-Tag
@@ -39,7 +39,7 @@ extends:
     - stage: BuildAndTest
       jobs:
       - job: BuildAndTest
-        displayName: BuildAndTest
+        displayName: Build And Test
 
         steps:
         - task: UsePythonVersion@0
@@ -60,21 +60,15 @@ extends:
             python -m pytest tests
           displayName: Run Tests
 
-        - ${{ if parameters.Publish }}:
-          - template: /azure-pipelines/MicroBuild.Publish.yml@MicroBuildTemplate
-            parameters: 
-              intent: 'PackageDistribution'
-              contentType: 'PyPi'
-              contentSource: 'Folder'
-              folderLocation: '$(Build.ArtifactStagingDirectory)\dist'
-              waitForReleaseCompletion: true
-              owners: 'piel@microsoft.com'
-              approvers: 'rdawson@microsoft.com'
-
         - task: 1ES.PublishPipelineArtifact@1
           inputs:
             targetPath: '$(Build.ArtifactStagingDirectory)'
-            artifactName: output
+            artifactName: drop
+
+        - ${{ if parameters.Publish }}:
+          - script: |
+              echo ##vso[build.addbuildtag]auto-release
+            displayName: 'Apply auto-release tag'
 
         # Because there is no build and no build scanning is enabled, there are no TSA files to upload.
         # Commenting this out for now.

--- a/azure-pipelines/release.yml
+++ b/azure-pipelines/release.yml
@@ -1,0 +1,58 @@
+trigger: none # We only want to trigger manually or based on resources
+pr: none
+
+resources:
+  repositories:
+  - repository: MicroBuildTemplate
+    type: git
+    name: 1ESPipelineTemplates/MicroBuildTemplate
+    ref: refs/tags/release
+  pipelines:
+  - pipeline: CI
+    source: py-deviceid-build
+    trigger:
+      tags:
+      - auto-release
+
+variables:
+  TeamName: 'Visual Studio Technical Insights'
+
+extends:
+  template: azure-pipelines/MicroBuild.1ES.Official.yml@MicroBuildTemplate
+  parameters:
+    sdl:
+      sourceAnalysisPool: VSEngSS-MicroBuild2022-1ES
+    
+    stages:
+    - stage: release
+      jobs:
+      - job: ReleaseJob
+        displayName: Publish pythong dist
+        pool: 
+          name: AzurePipelines-EO
+          demands:
+          - ImageOverride -equals 1ESPT-Windows2022
+        templateContext:
+          # https://eng.ms/docs/cloud-ai-platform/devdiv/one-engineering-system-1es/1es-docs/1es-pipeline-templates/features/releasepipelines/overview
+          type: releaseJob  # Required, this indicates this job is a release job
+          isProduction: true  # Required, must be 'true' or 'false'
+          inputs:  # All input build artifacts must be declared here
+          - input: pipelineArtifact  # Required, type of the input artifact
+            pipeline: CI # Required, name of the pipeline to download the artifacts
+            artifactName: drop  # Required, name of the pipeline artifact
+            targetPath: $(Pipeline.Workspace)/CI  # Optional, specifies where the artifact is downloaded
+        steps:
+        - checkout: none # for production release, this must always be none
+        - powershell: | 
+            Get-ChildItem -Path "$(Pipeline.Workspace)/CI/dist"
+          displayName: Display contents of dist
+        - ${{ if parameters.Publish }}:
+          - template: /azure-pipelines/MicroBuild.Publish.yml@MicroBuildTemplate
+            parameters: 
+              intent: 'PackageDistribution'
+              contentType: 'PyPi'
+              contentSource: 'Folder'
+              folderLocation: '$(Build.ArtifactStagingDirectory)\CI\dist'
+              waitForReleaseCompletion: true
+              owners: 'piel@microsoft.com'
+              approvers: 'rdawson@microsoft.com'


### PR DESCRIPTION
Seperated the build and release pipelines into seperate files. Releease pipeline will publish artifacts when the user checks the Publish checkbox on the build pipeline.